### PR TITLE
[FIX] defuse the problem of payment terminal field being emptied

### DIFF
--- a/pos_pinvandaag/models/res_config_settings.py
+++ b/pos_pinvandaag/models/res_config_settings.py
@@ -10,7 +10,7 @@ class ResConfigSettings(models.TransientModel):
     def set_values(self):
         super(ResConfigSettings, self).set_values()
         payment_method = self.env['pos.payment.method']
-        if not self.env['ir.config_parameter'].sudo().get_param('pos_pinvandaag.module_pos_pinvandaag'):
-            payment_method |= payment_method.search(
-                [('use_payment_terminal', '=', 'pinvandaag')])
-            payment_method.write({'use_payment_terminal': False})
+        #if not self.env['ir.config_parameter'].sudo().get_param('pos_pinvandaag.module_pos_pinvandaag'):
+        #    payment_method |= payment_method.search(
+        #        [('use_payment_terminal', '=', 'pinvandaag')])
+        #    payment_method.write({'use_payment_terminal': False})


### PR DESCRIPTION
Whenever someone does any configuration change in Odoo, the `use_payment_terminal` field of payment providers is being emptied out and has to be set again.

Probably this was meant as a cleanup action whenever people configure the Pinvandaag checkbox to False again, but even if the checkbox was on, that config parameter key has never been set so it will always trigger.

Real solution probably either to remove this feature or to actually link the config setting with that config parameter.